### PR TITLE
Add docs.nats.io examples to main

### DIFF
--- a/batch-publish/src/examples/java/io/synadia/examples/AtomicBatchDocExample.java
+++ b/batch-publish/src/examples/java/io/synadia/examples/AtomicBatchDocExample.java
@@ -1,0 +1,52 @@
+// Copyright (c) 2025 Synadia Communications Inc. All Rights Reserved.
+// See LICENSE and NOTICE file for details.
+
+package io.synadia.examples;
+
+import io.nats.client.Connection;
+import io.nats.client.JetStreamApiException;
+import io.nats.client.JetStreamManagement;
+import io.nats.client.Nats;
+import io.nats.client.api.PublishAck;
+import io.nats.client.api.StreamConfiguration;
+import io.synadia.bp.BatchPublisher;
+
+public class AtomicBatchDocExample {
+    static final String NATS_URL = "nats://localhost:4222";
+    static final String STREAM = "ORDERS";
+    static final String SUBJECTS = "orders.>";
+    static final String SUBJECT = "orders.created";
+    static final String BATCH_ID = "order-4273";
+
+    public static void main(String[] args) throws Exception {
+        try (Connection nc = Nats.connect(NATS_URL)) {
+            JetStreamManagement jsm = nc.jetStreamManagement();
+
+            // Ensure an ORDERS stream exists with atomic batch publishing enabled.
+            try { jsm.deleteStream(STREAM); } catch (JetStreamApiException ignore) {}
+            StreamConfiguration config = StreamConfiguration.builder()
+                .name(STREAM)
+                .subjects(SUBJECTS)
+                .allowAtomicPublish()
+                .build();
+            jsm.addStream(config);
+
+            // NATS-DOC-START
+            // One order, three line items, stored as a single atomic batch:
+            // either all three messages land in the stream, or none do.
+            BatchPublisher publisher = BatchPublisher.builder()
+                .connection(nc)
+                .batchId(BATCH_ID)
+                .build();
+
+            publisher.add(SUBJECT, "{\"sku\":\"NATS-TEE\",\"qty\":2}".getBytes());
+            publisher.add(SUBJECT, "{\"sku\":\"NATS-MUG\",\"qty\":1}".getBytes());
+            PublishAck ack = publisher.commit(SUBJECT, "{\"sku\":\"NATS-CAP\",\"qty\":1}".getBytes());
+
+            System.out.println("Committed batch [" + publisher.getBatchId() + "]"
+                + " of " + ack.getBatchSize() + " line items"
+                + " at stream sequence " + ack.getSeqno() + ".");
+            // NATS-DOC-END
+        }
+    }
+}

--- a/direct-batch/src/examples/java/io/synadia/examples/LearnJetStreamGetDirectBatchGet.java
+++ b/direct-batch/src/examples/java/io/synadia/examples/LearnJetStreamGetDirectBatchGet.java
@@ -1,0 +1,55 @@
+// Copyright (c) 2025 Synadia Communications Inc. All Rights Reserved.
+// See LICENSE and NOTICE file for details.
+
+package io.synadia.examples;
+
+import io.nats.client.Connection;
+import io.nats.client.JetStream;
+import io.nats.client.JetStreamApiException;
+import io.nats.client.JetStreamManagement;
+import io.nats.client.Nats;
+import io.nats.client.api.MessageInfo;
+import io.nats.client.api.StreamConfiguration;
+import io.synadia.direct.DirectBatchContext;
+import io.synadia.direct.MessageBatchGetRequest;
+
+import java.util.List;
+
+public class LearnJetStreamGetDirectBatchGet {
+    static final String NATS_URL = System.getenv("NATS_URL") != null
+        ? System.getenv("NATS_URL") : "nats://localhost:4222";
+    static final String STREAM = "ORDERS";
+    static final String SUBJECTS = "orders.>";
+
+    public static void main(String[] args) throws Exception {
+        try (Connection nc = Nats.connect(NATS_URL)) {
+            JetStreamManagement jsm = nc.jetStreamManagement();
+            JetStream js = nc.jetStream();
+
+            // Ensure an ORDERS stream exists with direct access enabled,
+            // then seed a few orders so the batch get has something to read.
+            try { jsm.deleteStream(STREAM); } catch (JetStreamApiException ignore) {}
+            jsm.addStream(StreamConfiguration.builder()
+                .name(STREAM)
+                .subjects(SUBJECTS)
+                .allowDirect(true)
+                .build());
+
+            js.publish("orders.created", "{\"id\":\"order-1\"}".getBytes());
+            js.publish("orders.created", "{\"id\":\"order-2\"}".getBytes());
+            js.publish("orders.created", "{\"id\":\"order-3\"}".getBytes());
+
+            // NATS-DOC-START
+            // Batch Direct Get: in one request, read up to 3 messages from the
+            // ORDERS stream starting at stream sequence 1, then iterate in order.
+            DirectBatchContext direct = new DirectBatchContext(nc, STREAM);
+            MessageBatchGetRequest request = MessageBatchGetRequest.batch(">", 3, 1);
+
+            List<MessageInfo> messages = direct.fetchMessageBatch(request);
+            for (MessageInfo mi : messages) {
+                System.out.println("sequence " + mi.getSeq() + " | subject " + mi.getSubject());
+            }
+            // NATS-DOC-END
+        }
+    }
+}


### PR DESCRIPTION
Moves the two documentation examples from the `jetstream-docs` branch onto main (additive only):
- `batch-publish/src/examples/java/io/synadia/examples/AtomicBatchDocExample.java`
- `direct-batch/src/examples/java/io/synadia/examples/LearnJetStreamGetDirectBatchGet.java`

Why: the new docs.nats.io build fetches these snippets at build time. On the side branch they get zero CI; on main both modules fold `src/examples/java` into the main sourceSet, so the path-filtered `bp-*`/`db-*` workflows compile them automatically — no gradle or workflow changes.

Note: please keep the `jetstream-docs` branch until the docs repo's fetch config is switched to `main` (follow-up PR there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)